### PR TITLE
Add provider name to the log filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pact-publish-verification: pact-test-config
 You need to add the following lines to your `.gitignore`
 
 ```
-pact.log
+pact-*.log
 pact/
 build/
 ```

--- a/pacttesting/testing.go
+++ b/pacttesting/testing.go
@@ -220,7 +220,7 @@ func TestWithStubServices(pactFilePaths []Pact, testFunc func()) {
 				"--pact-dir",
 				filepath.FromSlash(fmt.Sprintf(filepath.Join(dir, "target"))),
 				"--log",
-				filepath.FromSlash(fmt.Sprintf(filepath.Join(dir, "logs")) + "/" + "pact.log"),
+				filepath.FromSlash(fmt.Sprintf(filepath.Join(dir, "logs")) + "/" + "pact-" + p.Provider.Name + ".log"),
 				"--consumer",
 				p.Consumer.Name,
 				"--provider",
@@ -286,7 +286,7 @@ func IntegrationTest(pactFilePaths []Pact, testFunc func(), retryOptions ...retr
 			retryOptions = defaultRetryOptions
 		}
 		if err := retry.Do(verify, retryOptions...); err != nil {
-			log.Fatalf("Pact verification failed!! For more info on the error check the logs/pact.log file it is quite detailed")
+			log.Fatalf("Pact verification failed! For more info on the error check the logs/pact*.log files, they are quite detailed")
 		}
 	})
 }


### PR DESCRIPTION
When running multiple pact servers for different services, the log line gets corrupted because multiple services write to it in a very strange way. I've seen different processes adding their content in different places in the log, leaving the log hard to understand. Also There was some missing initialisation data, where pact logs the added interactions. I believe the processes override the log of each other.

I've separated the logs by provider, since during a test run we have always one single consumer with multiple providers.