### PR TITLE
update to pact-go 1.3

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -85,7 +85,7 @@
   revision = "bb74f1db0675b241733089d5a1faa5dd8b0ef57b"
 
 [[projects]]
-  digest = "1:e75a6c42f347194496a158c98bca3d7f902fa6cc46dada89755f138e57ddb47d"
+  digest = "1:da3741230349cb4381a1d27ed0ca6cb131c3e1b1a53312dc93dad69de7a4dce5"
   name = "github.com/pact-foundation/pact-go"
   packages = [
     "client",
@@ -96,8 +96,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "7b93cd4d125b96b7dca57518900a92ef5880ea7a"
-  version = "v1.1.0"
+  revision = "d5b427998d53d8d93d05fb683741213cdce2e9a3"
+  version = "v1.3.0"
 
 [[projects]]
   digest = "1:7231124c9669dfb54b82ef8b89f2735cf5d5d2529a23c6ac93a8c4b8bbb28b28"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,4 +35,4 @@
 
 [[constraint]]
   name = "github.com/pact-foundation/pact-go"
-  version = "v1.1.0"
+  version = "1.3.0"

--- a/vendor/github.com/pact-foundation/pact-go/client/publish_service.go
+++ b/vendor/github.com/pact-foundation/pact-go/client/publish_service.go
@@ -22,7 +22,7 @@ type PublishService struct {
 //    --provider-app-version
 //    --custom-provider-headers
 func (v *PublishService) NewService(args []string) Service {
-	log.Printf("[DEBUG] starting verification service with args: %v\n", args)
+	log.Printf("[DEBUG] starting publish service with args: %v\n", args)
 
 	v.Args = []string{
 		"publish",

--- a/vendor/github.com/pact-foundation/pact-go/dsl/message.go
+++ b/vendor/github.com/pact-foundation/pact-go/dsl/message.go
@@ -1,7 +1,7 @@
 package dsl
 
 import (
-	"fmt"
+	"log"
 	"reflect"
 )
 
@@ -90,7 +90,7 @@ func (p *Message) WithContent(content interface{}) *Message {
 // AsType specifies that the content sent through to the
 // consumer handler should be sent as the given type
 func (p *Message) AsType(t interface{}) *Message {
-	fmt.Println("[DEBUG] setting Message decoding to type:", reflect.TypeOf(t))
+	log.Println("[DEBUG] setting Message decoding to type:", reflect.TypeOf(t))
 	p.Type = t
 
 	return p

--- a/vendor/github.com/pact-foundation/pact-go/dsl/mock_client.go
+++ b/vendor/github.com/pact-foundation/pact-go/dsl/mock_client.go
@@ -4,12 +4,9 @@ import (
 	"github.com/pact-foundation/pact-go/types"
 )
 
-// TODO: Migrate tests from createMockClient to this package
-// where possible
-
 // Mock Client for testing the DSL package
 type mockClient struct {
-	VerifyProviderResponse   types.ProviderVerifierResponse
+	VerifyProviderResponse   []types.ProviderVerifierResponse
 	VerifyProviderError      error
 	Servers                  []*types.MockServer
 	StopServerResponse       *types.MockServer
@@ -57,7 +54,7 @@ func (p *mockClient) RemoveAllServers(server *types.MockServer) []*types.MockSer
 }
 
 // VerifyProvider runs the verification process against a running Provider.
-func (p *mockClient) VerifyProvider(request types.VerifyRequest) (types.ProviderVerifierResponse, error) {
+func (p *mockClient) VerifyProvider(request types.VerifyRequest) ([]types.ProviderVerifierResponse, error) {
 	return p.VerifyProviderResponse, p.VerifyProviderError
 }
 

--- a/vendor/github.com/pact-foundation/pact-go/dsl/mock_service.go
+++ b/vendor/github.com/pact-foundation/pact-go/dsl/mock_service.go
@@ -36,7 +36,7 @@ type MockService struct {
 func (m *MockService) call(method string, url string, content interface{}) error {
 	body, err := json.Marshal(content)
 	if err != nil {
-		fmt.Println(err)
+		log.Println("[ERROR]", err)
 		return err
 	}
 

--- a/vendor/github.com/pact-foundation/pact-go/install/installer.go
+++ b/vendor/github.com/pact-foundation/pact-go/install/installer.go
@@ -18,7 +18,7 @@ type Installer struct {
 
 const (
 	mockServiceRange = ">= 3.5.0, < 4.0.0"
-	verifierRange    = ">= 1.27.1, < 2.0.0"
+	verifierRange    = ">= 1.30.0, < 2.0.0"
 	brokerRange      = ">= 1.22.3"
 )
 

--- a/vendor/github.com/pact-foundation/pact-go/proxy/http.go
+++ b/vendor/github.com/pact-foundation/pact-go/proxy/http.go
@@ -138,6 +138,10 @@ func (c customTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	var DefaultTransport http.RoundTripper = transport
 
 	res, err := DefaultTransport.RoundTrip(r)
+	if err != nil {
+		log.Println("[ERROR]", err)
+		return nil, err
+	}
 	b, err = httputil.DumpResponse(res, false)
 	log.Println("[TRACE] proxied server response\n", string(b))
 

--- a/vendor/github.com/pact-foundation/pact-go/types/consumer_version_selector.go
+++ b/vendor/github.com/pact-foundation/pact-go/types/consumer_version_selector.go
@@ -1,0 +1,31 @@
+package types
+
+import "fmt"
+
+// ConsumerVersionSelector are the way we specify which pacticipants and
+// versions we want to use when configuring verifications
+// See https://docs.pact.io/selectors for more
+type ConsumerVersionSelector struct {
+	Pacticipant string `json:"pacticipant"`
+	Tag         string `json:"tag"`
+	Version     string `json:"version"`
+	Latest      bool   `json:"latest"`
+	All         bool   `json:"all"`
+}
+
+// Validate the selector configuration
+func (c *ConsumerVersionSelector) Validate() error {
+	if c.All && c.Pacticipant == "" {
+		return fmt.Errorf("must provide a Pacticpant")
+	}
+
+	if c.Pacticipant != "" && c.Tag == "" {
+		return fmt.Errorf("must provide at least a Tag if Pacticpant specified")
+	}
+
+	if c.All && c.Latest {
+		return fmt.Errorf("cannot select both All and Latest")
+	}
+
+	return nil
+}

--- a/vendor/github.com/pact-foundation/pact-go/types/provider_verifier_response.go
+++ b/vendor/github.com/pact-foundation/pact-go/types/provider_verifier_response.go
@@ -13,7 +13,14 @@ type ProviderVerifierResponse struct {
 		LineNumber      int         `json:"line_number"`
 		RunTime         float64     `json:"run_time"`
 		PendingMessage  interface{} `json:"pending_message"`
-		Exception       struct {
+		Mismatches      []string    `json:"mismatches"`
+		Pact            struct {
+			ConsumerName     string `json:"consumer_name"`
+			ProviderName     string `json:"provider_name"`
+			URL              string `json:"url"`
+			ShortDescription string `json:"short_description"`
+		} `json:"pact"`
+		Exception struct {
 			Class     string   `json:"class"`
 			Message   string   `json:"message"`
 			Backtrace []string `json:"backtrace"`
@@ -25,6 +32,10 @@ type ProviderVerifierResponse struct {
 		FailureCount                 int     `json:"failure_count"`
 		PendingCount                 int     `json:"pending_count"`
 		ErrorsOutsideOfExamplesCount int     `json:"errors_outside_of_examples_count"`
+		Notices                      []struct {
+			Text string `json:"text"`
+			When string `json:"when"`
+		} `json:"notices"`
 	} `json:"summary"`
 	SummaryLine string `json:"summary_line"`
 }

--- a/vendor/github.com/pact-foundation/pact-go/types/verify_request.go
+++ b/vendor/github.com/pact-foundation/pact-go/types/verify_request.go
@@ -2,9 +2,11 @@ package types
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/pact-foundation/pact-go/proxy"
 )
@@ -23,8 +25,16 @@ type VerifyRequest struct {
 	// Pact Broker URL for broker-based verification
 	BrokerURL string
 
-	// Tags to find in Broker for matrix-based testing
+	// Selectors are the way we specify which pacticipants and
+	// versions we want to use when configuring verifications
+	// See https://docs.pact.io/selectors for more
+	ConsumerVersionSelectors []ConsumerVersionSelector
+
+	// Retrieve the latest pacts with this consumer version tag
 	Tags []string
+
+	// Tags to apply to the provider application version
+	ProviderTags []string
 
 	// ProviderStatesSetupURL is the endpoint to post current provider state
 	// to on the Provider API.
@@ -89,6 +99,12 @@ type VerifyRequest struct {
 	// the Provider API. Useful for setting custom certificates, MASSL etc.
 	CustomTLSConfig *tls.Config
 
+	// Allow pending pacts to be included in verification (see pact.io/pending)
+	EnablePending bool
+
+	// Pull in new WIP pacts from _any_ tag (see pact.io/wip)
+	IncludeWIPPactsSince *time.Time
+
 	// Verbose increases verbosity of output
 	// Deprecated
 	Verbose bool
@@ -103,6 +119,7 @@ type VerifyRequest struct {
 // and should not be used outside of this library.
 func (v *VerifyRequest) Validate() error {
 	v.Args = []string{}
+	var err error
 
 	if len(v.PactURLs) != 0 {
 		v.Args = append(v.Args, v.PactURLs...)
@@ -110,6 +127,20 @@ func (v *VerifyRequest) Validate() error {
 
 	if len(v.PactURLs) == 0 && v.BrokerURL == "" {
 		return fmt.Errorf("One of 'PactURLs' or 'BrokerURL' must be specified")
+	}
+
+	if len(v.ConsumerVersionSelectors) != 0 {
+		for _, selector := range v.ConsumerVersionSelectors {
+			if err = selector.Validate(); err != nil {
+				return fmt.Errorf("invalid consumer version selector specified: %v", err)
+			}
+			body, err := json.Marshal(selector)
+			if err != nil {
+				return fmt.Errorf("invalid consumer version selector specified: %v", err)
+			}
+
+			v.Args = append(v.Args, "--consumer-version-selector", string(body))
+		}
 	}
 
 	if len(v.CustomProviderHeaders) != 0 {
@@ -172,6 +203,18 @@ func (v *VerifyRequest) Validate() error {
 
 	for _, tag := range v.Tags {
 		v.Args = append(v.Args, "--consumer-version-tag", tag)
+	}
+
+	for _, tag := range v.ProviderTags {
+		v.Args = append(v.Args, "--provider-version-tag", tag)
+	}
+
+	if v.EnablePending {
+		v.Args = append(v.Args, "--enable-pending")
+	}
+
+	if v.IncludeWIPPactsSince != nil {
+		v.Args = append(v.Args, "--include-wip-pacts-since", v.IncludeWIPPactsSince.Format(time.RFC3339))
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Earncef Sequeira <earncef.sequeira@form3.tech>

Updated pact-go to 1.3.0

Running dep ensure with this library uses pact-go 1.3.0 unless I override it which causes the errors listed below. I thought it's a better idea to update this library to use the latest pact-go instead.

```
# github.com/form3tech-oss/go-pact-testing/pacttesting [github.com/form3tech-oss/go-pact-testing/pacttesting.test]
pacttesting/message_testing.go:58:36: response.Examples undefined (type []types.ProviderVerifierResponse has no field or method Examples)
pacttesting/message_testing.go:179:3: cannot use response (type types.ProviderVerifierResponse) as type []types.ProviderVerifierResponse in return argument
pacttesting/message_testing.go:212:3: cannot use response (type types.ProviderVerifierResponse) as type []types.ProviderVerifierResponse in return argument
pacttesting/testing.go:362:36: response.Examples undefined (type []types.ProviderVerifierResponse has no field or method Examples)
```
