### PR TITLE
Update to set bound network address in viper

### DIFF
--- a/pacttesting/message_testing.go
+++ b/pacttesting/message_testing.go
@@ -181,7 +181,7 @@ func VerifyMessageProviderRaw(params PactProviderTestParams, request dsl.VerifyM
 
 	// Construct verifier request
 	verificationRequest := types.VerifyRequest{
-		ProviderBaseURL:            fmt.Sprintf("http://localhost:%d", port),
+		ProviderBaseURL:            fmt.Sprintf("http://%s:%d", getBindAddress(), port),
 		PactURLs:                   request.PactURLs,
 		BrokerURL:                  request.BrokerURL,
 		Tags:                       request.Tags,
@@ -195,7 +195,7 @@ func VerifyMessageProviderRaw(params PactProviderTestParams, request dsl.VerifyM
 
 	mux.HandleFunc("/", messageHandler(request.MessageHandlers, request.StateHandlers))
 
-	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", getBindAddress(), port))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -204,7 +204,7 @@ func VerifyMessageProviderRaw(params PactProviderTestParams, request dsl.VerifyM
 	log.Printf("[DEBUG] API handler starting: port %d (%s)", port, ln.Addr())
 	go http.Serve(ln, mux)
 
-	portErr := waitForPort(port, "tcp", "localhost", 5*time.Second,
+	portErr := waitForPort(port, "tcp", getBindAddress(), 5*time.Second,
 		fmt.Sprintf(`Timed out waiting for Daemon on port %d - are you sure it's running?`, port))
 
 	if portErr != nil {
@@ -224,7 +224,7 @@ var waitForPort = func(port int, network string, address string, timeoutDuration
 		select {
 		case <-timeout:
 			log.Printf("[ERROR] Expected server to start < %s. %s", timeoutDuration, message)
-			return fmt.Errorf("Expected server to start < %s. %s", timeoutDuration, message)
+			return fmt.Errorf("expected server to start < %s. %s", timeoutDuration, message)
 		case <-time.After(50 * time.Millisecond):
 			_, err := net.Dial(network, fmt.Sprintf("%s:%d", address, port))
 			if err == nil {

--- a/pacttesting/testing.go
+++ b/pacttesting/testing.go
@@ -179,7 +179,7 @@ func PreassignPorts(pactFilePaths []Pact) {
 				panic(err)
 			}
 			serverPortMap[key] = port
-			serverAddress := fmt.Sprintf("http://localhost:%d", port)
+			serverAddress := fmt.Sprintf("http://%s:%d", getBindAddress(), port)
 			viper.Set(p.Provider.Name, serverAddress)
 		}
 	}
@@ -205,10 +205,7 @@ func TestWithStubServices(pactFilePaths []Pact, testFunc func()) {
 	}
 
 	// Allow binding to 0.0.0.0 if desired
-	bind := "127.0.0.1"
-	if b := os.Getenv("PACT_BIND_ADDRESS"); len(b) > 0 {
-		bind = b
-	}
+	bind := getBindAddress()
 
 	for _, p := range pacts {
 		key := p.Provider.Name + p.Consumer.Name
@@ -399,4 +396,13 @@ func VerifyProviderPacts(params PactProviderTestParams) {
 			}
 		})
 	}
+}
+
+func getBindAddress() string {
+	// Allow binding to 0.0.0.0 if desired
+	bind := "127.0.0.1"
+	if b := os.Getenv("PACT_BIND_ADDRESS"); len(b) > 0 {
+		bind = b
+	}
+	return bind
 }


### PR DESCRIPTION
We were always setting 127.0.0.1 as the network address with viper
even though we support setting the PACT_BIND_ADDRESS through env
variable. We should read this to see if we are running on a different
address and set the correct value with viper.

Signed-off-by: Alistair Hey <alistair.hey@form3.tech>