### PR TITLE
adding alternative api

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ pacttesting.AddPactInteraction(s.t, "testservicea", "go-pact-testing", (&dsl.Int
 // then
 // check that the interactions are called
 pacttesting.VerifyInteractions(s.t, "testservicea", "go-pact-testing")
+
+// pact servers are re-used, so it is best to remove the interactions before or after the each test
+pacttesting.ResetPacts()
 ```
 
 ### Integration Test

--- a/README.md
+++ b/README.md
@@ -55,8 +55,44 @@ Consumer testing uses pact files to define mocks for any dependent services whic
 can be used to provide expected responses to tests and also verify that interactions were indeed made. Once testing is 
 complete, consumer pacts are uploaded to the pact broker via the `pact-publish` task, for verification by provider tests. 
 
-Consumer tests can be written using the `IntegrationTest` function. Pacts should be stored in a directory called 'pacts': 
+There are two ways to define consumer tests - the original integration test or the newer DSL test. 
+
+### DSL
+
+DSL tests define interactions and verify responses as part of the test. This may result in more expressive tests when using BDD style tests
+
+```go
+// pact servers can be optionally started during test setup. A free port is chosen automatically. This may be useful if the url needs to be injected into the service under test.
+url := pacttesting.EnsurePactRunning("testservicea", "go-pact-testing")
+
+// given
+// test service returns 200 for a get request
+// .. either from json
+pacttesting.AddPact(s.t,"testservicea.get.test")
+// .. or via code
+pacttesting.AddPactInteraction(s.t, "testservicea", "go-pact-testing", (&dsl.Interaction{}).
+		UponReceiving("Request for a test endpoint A").
+		WithRequest(dsl.Request{
+			Method: "GET",
+			Path:   dsl.String("/v1/test"),
+		}).
+		WillRespondWith(dsl.Response{
+			Status:  200,
+			Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json; charset=utf-8")},
+			Body:    map[string]string{"foo": "bar"},
+		}))
+
+// when 
+// ... functionality that invokes the service
+
+// then
+// check that the interactions are called
+pacttesting.VerifyInteractions(s.t, "testservicea", "go-pact-testing")
 ```
+
+### Integration Test
+Consumer tests can be written using the `IntegrationTest` function. Pacts should be stored in a directory called 'pacts': 
+```go
 IntegrationTest([]Pact{"testservicea.get.test", "testserviceb.get.test"}, func() {
     // test-code-here. 
 })

--- a/pacttesting/pact_testing_integration_stage_test.go
+++ b/pacttesting/pact_testing_integration_stage_test.go
@@ -1,7 +1,7 @@
 package pacttesting
 
 import (
-	"github.com/pact-foundation/pact-go/dsl"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -12,8 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"fmt"
-
+	"github.com/pact-foundation/pact-go/dsl"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )

--- a/pacttesting/pact_testing_integration_stage_test.go
+++ b/pacttesting/pact_testing_integration_stage_test.go
@@ -1,6 +1,7 @@
 package pacttesting
 
 import (
+	"github.com/pact-foundation/pact-go/dsl"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -30,6 +31,15 @@ type pactTestingStage struct {
 }
 
 func PactTestingTest(t *testing.T) (*pactTestingStage, *pactTestingStage, *pactTestingStage) {
+	s := &pactTestingStage{
+		t: t,
+	}
+
+	return s, s, s
+}
+
+func InlinePactTestingTest(t *testing.T) (*pactTestingStage, *pactTestingStage, *pactTestingStage) {
+	ResetPacts()
 	s := &pactTestingStage{
 		t: t,
 	}
@@ -186,4 +196,32 @@ func (s *pactTestingStage) the_service_has_a_preassigned_port() *pactTestingStag
 
 func (s *pactTestingStage) the_test_panics() {
 	panic("Test Panic")
+}
+func (s *pactTestingStage) test_service_a_returns_200_for_get() *pactTestingStage {
+	AddPactInteraction(s.t, "testservicea", "go-pact-testing", (&dsl.Interaction{}).
+		UponReceiving("Request for a test endpoint A").
+		WithRequest(dsl.Request{
+			Method: "GET",
+			Path:   dsl.String("/v1/test"),
+		}).
+		WillRespondWith(dsl.Response{
+			Status:  200,
+			Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json; charset=utf-8")},
+			Body:    map[string]string{"foo": "bar"},
+		}))
+	return s
+}
+
+func (s *pactTestingStage) test_service_a_returns_200_for_get_from_file() *pactTestingStage {
+	AddPact(s.t, "testservicea.get.test")
+	return s
+}
+
+func (s *pactTestingStage) test_service_a_is_called() *pactTestingStage {
+	return s.the_pact_for_service_a_is_called()
+}
+
+func (s *pactTestingStage) test_service_a_was_invoked() *pactTestingStage {
+	VerifyInteractions(s.t, "testservicea", "go-pact-testing")
+	return s
 }

--- a/pacttesting/pact_testing_integration_test.go
+++ b/pacttesting/pact_testing_integration_test.go
@@ -7,7 +7,6 @@ import (
 
 func TestAcc_verify_pact_with_single_pact(t *testing.T) {
 	IntegrationTest([]Pact{"testservicea.get.test"}, func() {
-
 		given, when, then := PactTestingTest(t)
 
 		given.
@@ -19,9 +18,33 @@ func TestAcc_verify_pact_with_single_pact(t *testing.T) {
 		then.
 			the_response_for_service_a_should_be_200_ok().and().
 			no_error_should_be_returned_from_service_a()
-
 	})
+}
 
+func TestAcc_verify_pact_with_single_pact_dsl(t *testing.T) {
+	given, when, then := InlinePactTestingTest(t)
+
+	given.
+		test_service_a_returns_200_for_get()
+
+	when. // mock servers started before here
+		test_service_a_is_called()
+
+	then.
+		test_service_a_was_invoked() // verify pacts are called
+}
+
+func TestAcc_verify_pact_with_single_pact_file(t *testing.T) {
+	given, when, then := InlinePactTestingTest(t)
+
+	given.
+		test_service_a_returns_200_for_get_from_file()
+
+	when. // mock servers started before here
+		test_service_a_is_called()
+
+	then.
+		test_service_a_was_invoked() // verify pacts are called
 }
 
 func TestAcc_verify_two_pacts_from_two_providers(t *testing.T) {

--- a/pacttesting/testing.go
+++ b/pacttesting/testing.go
@@ -1,20 +1,17 @@
 package pacttesting
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
+	c "os/exec"
 	"path/filepath"
 	"strings"
-	"time"
-
-	"bytes"
-	c "os/exec"
 	"sync"
-
 	"testing"
+	"time"
 
 	retry "github.com/giantswarm/retry-go"
 	"github.com/pact-foundation/pact-go/dsl"
@@ -22,6 +19,7 @@ import (
 	"github.com/phayes/freeport"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 )
 
 type Pact = string
@@ -231,7 +229,6 @@ func TestWithStubServices(pactFilePaths []Pact, testFunc func()) {
 // AddPact loads a pact definition from a file and ensures that stub servers are running.
 func AddPact(t *testing.T, filename string) {
 	pactFilePaths := []string{filename}
-	PreassignPorts(pactFilePaths)
 	buildPactClientOnce()
 	pacts := groupByProvider(readAllPacts(pactFilePaths))
 	for _, p := range pacts {

--- a/pacttesting/testing.go
+++ b/pacttesting/testing.go
@@ -309,6 +309,7 @@ func EnsurePactRunning(provider, consumer string) string {
 
 		assignPorts(provider, consumer)
 		port := serverPortMap[key]
+		buildPactClientOnce()
 		server := pactClient.StartServer(args, port)
 		serverAddress := fmt.Sprintf("http://%s:%d", bind, port)
 		mockServer := &MockServer{


### PR DESCRIPTION
Details in the updated README.

This will allow us to move away from tests like

```go
func TestAcc_verify_pact_with_single_pact(t *testing.T) {
	IntegrationTest([]Pact{"testservicea.get.test"}, func() {
		given, when, then := PactTestingTest(t)

		given.
			the_test_is_using_a_single_pact() // syntactic only - empty method

		when.
			the_pact_for_service_a_is_called()

		then.
			the_response_for_service_a_should_be_200_ok().and().// syntactic only - empty method
			no_error_should_be_returned_from_service_a()// syntactic only - empty method
	}) // actual magic happens here, 
}
```

to:
```go
func TestAcc_verify_pact_with_single_pact_dsl(t *testing.T) {
	given, when, then := InlinePactTestingTest(t)

	given.
		test_service_a_returns_200_for_get() // defines the interactions (either via json file or in code), checks mock servers running

	when. 
		test_service_a_is_called()

	then.
		test_service_a_was_invoked() // verifies pacts have been  called
}
```