### PR TITLE
Reset pacts only if server is running

### DIFF
--- a/pacttesting/testing.go
+++ b/pacttesting/testing.go
@@ -192,6 +192,9 @@ func assignPort(provider, consumer string) int {
 
 func ResetPacts() {
 	for key, pactServer := range pactServers {
+		if !pactServer.Running {
+			continue
+		}
 		err := pactServer.DeleteInteractions()
 		if err != nil {
 			log.WithError(err).Errorf("unable to delete configured interactions for %s", key)


### PR DESCRIPTION
When a server is not running, we should skip that to avoid refused connection errors.

The above can happen, for example, if there is a `PreassignPorts()` call in setup, but no interaction is added for Pact before a call to `ResetPacts()`.