### PR TITLE
Reinstate implementation of StopMockServers

### DIFF
--- a/pacttesting/mock_service.go
+++ b/pacttesting/mock_service.go
@@ -98,7 +98,7 @@ func (m *MockServer) writePidFile() {
 func (m *MockServer) Stop() error {
 	p, err := os.FindProcess(m.Pid)
 	if err == nil {
-		err = p.Signal(os.Interrupt)
+		err = p.Signal(syscall.SIGTERM)
 		if err != nil {
 			return errors.WithMessage(err, fmt.Sprintf("failed to send interrupt to pid %d", m.Pid))
 		}
@@ -113,7 +113,10 @@ func (m *MockServer) Stop() error {
 			}
 			return nil
 		}, retry.Timeout(5*time.Second), retry.Sleep(200*time.Millisecond)); err != nil {
-			p.Kill()
+			err = p.Kill()
+			if err != nil {
+				return errors.WithMessage(err, "failed to kill process")
+			}
 			return errors.New("failed to stop server, attempting kill")
 		} else {
 			log.Printf("stopped server")

--- a/pacttesting/pact_testing_integration_stage_test.go
+++ b/pacttesting/pact_testing_integration_stage_test.go
@@ -296,11 +296,8 @@ func (s *pactTestingStage) a_mock_server_stops() *pactTestingStage {
 }
 
 func (s *pactTestingStage) pact_verification_written_to_disk() *pactTestingStage {
-	err := retry.Do(func() error {
-		_, fileErr := os.Stat("target/go-pact-testing-testservicea.json")
-		return fileErr
-	}, retry.Sleep(200*time.Millisecond), retry.Timeout(1*time.Second))
 
+	_, err := os.Stat("target/go-pact-testing-testservicea.json")
 	assert.NoError(s.t, err)
 
 	return s

--- a/pacttesting/pact_testing_integration_test.go
+++ b/pacttesting/pact_testing_integration_test.go
@@ -226,6 +226,21 @@ func TestAcc_pact_server_started(t *testing.T) {
 		a_new_mock_server_is_started()
 }
 
+func TestAcc_pact_file_written_to_disk(t *testing.T) {
+
+	given, when, then := InlinePactTestingTest(t)
+
+	given.
+		clean_slate().and().
+		pact_verification_completed()
+
+	when.
+		a_mock_server_stops()
+
+	then.
+		pact_verification_written_to_disk()
+}
+
 func TestMain(m *testing.M) {
 
 	result := m.Run()

--- a/pacttesting/testing.go
+++ b/pacttesting/testing.go
@@ -383,8 +383,15 @@ func IntegrationTest(pactFilePaths []Pact, testFunc func(), retryOptions ...retr
 	})
 }
 
-// Deprecated: StopMockServers left here for backwards compatibility, does not stop anything.
 func StopMockServers() {
+	for key, s := range pactServers {
+		err := s.Stop()
+		if err != nil {
+			log.WithError(err).Errorf("failed to stop server for consumer(%s), provider(%s)", s.Consumer, s.Provider)
+		} else {
+			delete(pactServers, key)
+		}
+	}
 }
 
 func VerifyAll() error {


### PR DESCRIPTION
This is neccessary to ensure pact files are flushed to disk after
verification in order to be published to the broker.

This is related to issue https://github.com/form3tech-oss/go-pact-testing/issues/19. There is code that relies on pact verifications being written into the target directory. The write to disk happens once the pact-mock-service is stopped and since we are no longer stopping the server, we are not getting the verified pacts in the target directory. This breaks pact verification flow during the CI. 


Co-authored-by: Viktor Peacock <viktor.peacock@form3.tech>