### PR TITLE
Path separator gets removed from generated filepath.

### DIFF
--- a/pacttesting/pact_file_split.go
+++ b/pacttesting/pact_file_split.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -49,10 +50,18 @@ func SplitPactBulkFile(bulkFilePath string, outputDirPath string, requestFilters
 		if jsonErr != nil {
 			return errors.Wrap(jsonErr, "Couldn't change interaction to test case - interaction idx: "+strconv.Itoa(idx))
 		}
-		tcFilePath := filepath.Join(outputDirPath, tc.Interactions[0].Description+".json")
+
+		description := sanitize(tc.Interactions[0].Description)
+		tcFilePath := filepath.Join(outputDirPath, description+".json")
 		if writeErr := ioutil.WriteFile(tcFilePath, json, os.ModePerm); writeErr != nil {
 			return errors.Wrap(writeErr, "Couldn't write test case to file - interaction idx: "+strconv.Itoa(idx)+", output file path: "+tcFilePath)
 		}
 	}
 	return nil
+}
+
+func sanitize(value string) string {
+	value = strings.ReplaceAll(value, string(os.PathSeparator), "")
+
+	return value
 }

--- a/pacttesting/pact_testing_integration_test.go
+++ b/pacttesting/pact_testing_integration_test.go
@@ -137,6 +137,20 @@ func TestProvider_Should_Split_Bulk_File(t *testing.T) {
 
 }
 
+func TestProvider_GeneratesPactFiles_WithValidNames(t *testing.T) {
+
+	given, when, then := PactTestingTest(t)
+
+	given.
+		a_bulk_pact_file_with_invalid_descriptions()
+
+	when.
+		file_is_split()
+
+	then.
+		pact_file_names_exclude_path_separator()
+}
+
 func TestAcc_verify_all(t *testing.T) {
 	IntegrationTest([]Pact{"testservicea.get.test"}, func() {
 
@@ -152,7 +166,6 @@ func TestAcc_verify_all(t *testing.T) {
 		then.
 			the_response_for_service_a_should_be_200_ok().and().
 			no_error_should_be_returned_from_the_verify()
-
 	})
 
 }

--- a/pacttesting/pacts/testservices.get.bulk.invaliddescription.test.json
+++ b/pacttesting/pacts/testservices.get.bulk.invaliddescription.test.json
@@ -1,0 +1,38 @@
+{
+  "provider" : { "name" : "testservicea"  },
+  "consumer" : { "name" : "go-pact-testing"  },
+  "interactions" : [
+    {
+      "description" : "Request for a test endpoint A/COR",
+      "request" : {
+        "method" : "GET",
+        "path" : "/v1/test"
+      },
+      "response" : {
+        "status" : 200,
+        "headers" : {
+          "Content-Type" : "application/json; charset=utf-8"
+        },
+        "body" : {
+          "foo": "bar"
+        }
+      }
+    },
+    {
+      "description" : "Request for a test endpoint B/B2B",
+      "request" : {
+        "method" : "GET",
+        "path" : "/v1/test"
+      },
+      "response" : {
+        "status" : 200,
+        "headers" : {
+          "Content-Type" : "application/json; charset=utf-8"
+        },
+        "body" : {
+          "foo": "bar"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Fixes the issue whereby we cannot generate a pact file with a / in the description.

Co-authored-by: Ryan Gough <ryan.gough@form3.tech>