### PR TITLE
adding details to mock service connection error

### DIFF
--- a/pacttesting/testing.go
+++ b/pacttesting/testing.go
@@ -320,6 +320,10 @@ func EnsurePactRunning(provider, consumer string) string {
 		setPathOnce()
 		mockServicePath := pactPath + "/pact-mock-service"
 		cmd := exec.Command(mockServicePath, args...)
+
+		var outBuf bytes.Buffer
+		cmd.Stdout = &outBuf
+
 		cmd.Env = os.Environ()
 
 		log.Debugf("%s %s", mockServicePath, strings.Join(args, " "))
@@ -341,7 +345,7 @@ func EnsurePactRunning(provider, consumer string) string {
 			return mockServer.call("GET", serverAddress, nil)
 		}, retry.Delay(25*time.Millisecond), retry.Attempts(200))
 		if err != nil {
-			log.WithError(err).Fatalf(`timed out waiting for mock server to report healthy, pid %d`, mockServer.Pid)
+			log.WithError(err).Fatalf(`timed out waiting for mock server to report healthy, pid:%d stdout: %s`, mockServer.Pid, outBuf.String())
 		}
 
 		mockServer.writePidFile()


### PR DESCRIPTION
Current solution was hiding useful details when running go pact tests with mock service.

This addition will just output `stdout` from mockservice start command
improving visibility on what is happening in a scenario when mock
service is not starting up correctly.

This should help identify scenarios of mock service not starting - like:
- port already taken
- unable to bind socket to HOST_IP
- configuration error