### PR TITLE
Use non-annotated git tags to get the version

### DIFF
--- a/pacttesting/testing.go
+++ b/pacttesting/testing.go
@@ -126,7 +126,7 @@ func getTopLevelDir() (string, error) {
 }
 
 func getVersion() (string, error) {
-	gitCommand := exec.Command("git", "describe")
+	gitCommand := exec.Command("git", "describe", "--tags")
 	var out bytes.Buffer
 	gitCommand.Stdout = &out
 	err := gitCommand.Run()


### PR DESCRIPTION
Enable support for repositories which only use simple tags as release tags. If repositories use annotated tags they should still work.

Currently, the tests fail if the repository does not have annotated git tags.