### PR TITLE
Expose Pact servers' base URL as an ENV variable

### DIFF
--- a/pacttesting/mock_service.go
+++ b/pacttesting/mock_service.go
@@ -164,7 +164,11 @@ func loadRunningServer(provider, consumer string) *MockServer {
 	pactServers[provider+consumer] = &server
 	viper.Set(provider, server.BaseURL)
 	//Also set the base url as an environment variable to remove dependency on viper
-	os.Setenv("PACTTESTING_" + strings.ToUpper(provider), strings.Replace(server.BaseURL, "-", "_", -1))
+	key := "PACTTESTING_" + strings.ToUpper(strings.Replace(provider, "-", "_", -1))
+	err = os.Setenv(key, server.BaseURL)
+	if err != nil {
+		log.WithError(err).Errorf("Failed to set environment variable %s", key)
+	}
 	log.Infof("Reusing existing mock service for %s at %s, pid %d", server.Provider, server.BaseURL, server.Pid)
 	return &server
 }

--- a/pacttesting/mock_service.go
+++ b/pacttesting/mock_service.go
@@ -164,7 +164,7 @@ func loadRunningServer(provider, consumer string) *MockServer {
 	pactServers[provider+consumer] = &server
 	viper.Set(provider, server.BaseURL)
 	//Also set the base url as an environment variable to remove dependency on viper
-	os.Setenv("PACTTESTING_" + strings.ToUpper(provider), server.BaseURL)
+	os.Setenv("PACTTESTING_" + strings.ToUpper(provider), strings.Replace(server.BaseURL, "-", "_", -1))
 	log.Infof("Reusing existing mock service for %s at %s, pid %d", server.Provider, server.BaseURL, server.Pid)
 	return &server
 }

--- a/pacttesting/mock_service.go
+++ b/pacttesting/mock_service.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -162,6 +163,8 @@ func loadRunningServer(provider, consumer string) *MockServer {
 	server.Running = true
 	pactServers[provider+consumer] = &server
 	viper.Set(provider, server.BaseURL)
+	//Also set the base url as an environment variable to remove dependency on viper
+	os.Setenv("PACTTESTING_" + strings.ToUpper(provider), server.BaseURL)
 	log.Infof("Reusing existing mock service for %s at %s, pid %d", server.Provider, server.BaseURL, server.Pid)
 	return &server
 }


### PR DESCRIPTION
relatesto: form3tech/project-euro-board#1291

We are working towards removing viper from the sepadd-gateway code
and eventually from all gateways. This pact testing library uses
viper as a means of providing the stub url (with randomly selected
port) to the gateway pact tests. If we want to remove viper from the
gateway, we first need to remove this dependency on viper in pact
testing.