### PR TITLE
fix: add explicit cmd.Wait() so the process doesn't become a zombie

### DIFF
--- a/pacttesting/pact_testing_integration_stage_test.go
+++ b/pacttesting/pact_testing_integration_stage_test.go
@@ -2,6 +2,7 @@ package pacttesting
 
 import (
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -265,6 +266,12 @@ func (s *pactTestingStage) a_mock_interaction_is_added() *pactTestingStage {
 	return s
 }
 
+func (s *pactTestingStage) a_mock_server() *pactTestingStage {
+	s.test_service_a_returns_200_for_get_from_file()
+	s.testServiceApid = pactServers["testserviceago-pact-testing"].Pid
+	return s
+}
+
 func (s *pactTestingStage) no_new_server_is_started() *pactTestingStage {
 	assert.Equal(s.t, s.testServiceApid, pactServers["testserviceago-pact-testing"].Pid)
 	return s
@@ -319,5 +326,20 @@ func (s *pactTestingStage) pact_verification_written_to_disk() *pactTestingStage
 	_, err := os.Stat("target/go-pact-testing-testservicea.json")
 	assert.NoError(s.t, err)
 
+	return s
+}
+
+func (s *pactTestingStage) the_process_is_not_running() *pactTestingStage {
+	p, _ := os.FindProcess(s.testServiceApid)
+	// apparently os.FindProcess never returns an error on Linux
+	err := p.Kill()
+	assert.Errorf(s.t, err, "os: process already finished")
+	return s
+}
+
+func (s *pactTestingStage) the_corresponding_PID_file_is_removed() *pactTestingStage {
+	_, err := os.Stat("pact/pids/pact-testservicea-go-pact-testing.json")
+	var pathErr *fs.PathError
+	assert.ErrorAs(s.t, err, &pathErr)
 	return s
 }

--- a/pacttesting/pact_testing_integration_test.go
+++ b/pacttesting/pact_testing_integration_test.go
@@ -254,6 +254,21 @@ func TestAcc_pact_file_written_to_disk(t *testing.T) {
 		pact_verification_written_to_disk()
 }
 
+func TestAcc_mock_server_stops_cleanly(t *testing.T) {
+
+	given, when, then := InlinePactTestingTest(t)
+
+	given.
+		a_mock_server()
+
+	when.
+		a_mock_server_stops()
+
+	then.
+		the_process_is_not_running().and().
+		the_corresponding_PID_file_is_removed()
+}
+
 func TestMain(m *testing.M) {
 
 	result := m.Run()

--- a/pacttesting/testing.go
+++ b/pacttesting/testing.go
@@ -351,6 +351,11 @@ func EnsurePactRunning(provider, consumer string) string {
 			log.WithError(err).Fatalf("failed to start mock server")
 		}
 
+		// Avoid zombies
+		go func() {
+			cmd.Wait()
+		}()
+
 		serverAddress := fmt.Sprintf("http://%s:%d", bind, port)
 		mockServer = &MockServer{
 			Port:     port,


### PR DESCRIPTION
The pact mock servers are started via exec, but are not detached from the parent process. As a result, when the process is killed by the `StopMockServers`, it is not reaped by the OS and is kept as a zombie, while the parent is still around.
`cmd.Wait()` ensures the process is properly reaped by the OS when stops.

Fixes #35