### PR TITLE
fix: The main process hangs forever if the mock server failed to start

### DIFF
--- a/pacttesting/fatal_handler_test.go
+++ b/pacttesting/fatal_handler_test.go
@@ -1,0 +1,44 @@
+package pacttesting
+
+import (
+	"errors"
+
+	"github.com/sirupsen/logrus"
+)
+
+var errFatal = errors.New("fatal error")
+
+type FatalHandler struct {
+	logger   *logrus.Logger
+	exitCode int
+}
+
+func NewFatalHandler(logger *logrus.Logger) *FatalHandler {
+	return &FatalHandler{
+		logger: logger,
+	}
+}
+
+func NewFatalHandlerDefault() *FatalHandler {
+	return NewFatalHandler(logrus.StandardLogger())
+}
+
+func (h *FatalHandler) Handle(fn func()) {
+	defer func(origExitFunc func(int)) {
+		h.logger.ExitFunc = origExitFunc
+		if err := recover(); err != nil && err != errFatal {
+			panic(err)
+		}
+	}(h.logger.ExitFunc)
+
+	h.exitCode = 0
+	h.logger.ExitFunc = func(exitCode int) {
+		h.exitCode = exitCode
+		panic(errFatal)
+	}
+	fn()
+}
+
+func (h *FatalHandler) ExitCode() int {
+	return h.exitCode
+}

--- a/pacttesting/pact_testing_integration_test.go
+++ b/pacttesting/pact_testing_integration_test.go
@@ -269,12 +269,21 @@ func TestAcc_mock_server_stops_cleanly(t *testing.T) {
 		the_corresponding_PID_file_is_removed()
 }
 
+func TestAcc_main_process_fails_on_mock_server_startup_crash(t *testing.T) {
+	given, when, then := InlinePactTestingTest(t)
+
+	given.
+		a_broken_mock_server()
+
+	when.
+		the_mock_server_crashes_on_startup()
+
+	then.
+		the_main_process_fails()
+}
+
 func TestMain(m *testing.M) {
-
 	result := m.Run()
-
 	StopMockServers()
-
 	os.Exit(result)
-
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -83,6 +83,7 @@ github.com/spf13/viper/internal/encoding/yaml
 # github.com/stretchr/testify v1.8.2
 ## explicit; go 1.13
 github.com/stretchr/testify/assert
+github.com/stretchr/testify/require
 # github.com/subosito/gotenv v1.4.2
 ## explicit; go 1.18
 github.com/subosito/gotenv


### PR DESCRIPTION
When checking the mock server health, the retry logic did not take into account that `retry.Do()` uses an exponential backoff strategy by default, which combined with 200 attempts results in an enormous timeout.